### PR TITLE
fix(commands): standardize PowerShell execution syntax

To ensure compatibility with Windows environments and consistent behavior across the extension, this PR updates all TOML command definitions to use the Call Operator (`&`) syntax when invoking PowerShell scripts.

### DIFF
--- a/commands/eat-pickle.toml
+++ b/commands/eat-pickle.toml
@@ -9,6 +9,6 @@ bash "${extensionPath}/scripts/cancel.sh"
 
 **Windows (PowerShell):**
 ```powershell
-pwsh -File "${extensionPath}/scripts/cancel.ps1"
+& "${extensionPath}/scripts/cancel.ps1"
 ```
 """

--- a/commands/pickle-prd.toml
+++ b/commands/pickle-prd.toml
@@ -15,7 +15,7 @@ bash "${extensionPath}/scripts/setup.sh" --paused $ARGUMENTS
 ```
 **Windows (PowerShell):**
 ```powershell
-pwsh -File "${extensionPath}/scripts/setup.ps1" -paused $ARGUMENTS
+& "${extensionPath}/scripts/setup.ps1" -paused $ARGUMENTS
 ```
 **CRITICAL**: Capture the `Path:` from the output. That is your `SESSION_DIR`.
 

--- a/commands/pickle.toml
+++ b/commands/pickle.toml
@@ -23,7 +23,7 @@ bash "${extensionPath}/scripts/setup.sh" $ARGUMENTS
 ```
 **Windows (PowerShell):**
 ```powershell
-pwsh -File "${extensionPath}/scripts/setup.ps1" $ARGUMENTS
+& "${extensionPath}/scripts/setup.ps1" $ARGUMENTS
 ```
 **Supported Arguments for setup.sh:**
 - `--max-iterations <N>`: Maximum number of loop iterations.

--- a/commands/send-to-morty.toml
+++ b/commands/send-to-morty.toml
@@ -24,7 +24,7 @@ bash "${extensionPath}/scripts/worker_setup.sh" $ARGUMENTS
 ```
 **Windows (PowerShell):**
 ```powershell
-"${extensionPath}/scripts/worker_setup.ps1" $ARGUMENTS
+& "${extensionPath}/scripts/worker_setup.ps1" $ARGUMENTS
 ```
 
 **Step 2: Execution**


### PR DESCRIPTION
## Description

This PR addresses an issue where `pwsh -File` was being used inconsistently and potentially incorrectly in `commands/*.toml` files.

According to PowerShell documentation and user feedback, when executing a script path enclosed in quotes (due to variable expansion like `"${extensionPath}/..."`), the Call Operator (`&`) is required for execution.

## Changes

- Updated `commands/eat-pickle.toml`
- Updated `commands/pickle.toml`
- Updated `commands/pickle-prd.toml`
- Updated `commands/send-to-morty.toml`

All files now use the format:
```powershell
& "${extensionPath}/scripts/script_name.ps1" $ARGUMENTS
```

## Checklist

- [x] Tested locally (verified syntax matches PowerShell requirements)
- [x] All 4 command files updated
- [x] No `pwsh -File` instances remain in `commands/`
